### PR TITLE
adds ability to add prop to inner span on iconbutton

### DIFF
--- a/shared-components/src/components/button/BaseButton.tsx
+++ b/shared-components/src/components/button/BaseButton.tsx
@@ -5,6 +5,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   postfix?: string;
   icon?: () => JSX.Element;
   className?: string;
+  iconClass?: string;
 }
 
 interface BaseButtonProps extends ButtonProps {
@@ -22,6 +23,7 @@ export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
       isLoading = false,
       postfix,
       icon: Icon,
+      iconClass = "",
       disabled,
       className = "",
       "aria-busy": ariaBusy,
@@ -40,7 +42,7 @@ export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
       } ${className}`}
     >
       {Icon && (
-        <span data-testid="rds-button__icon" className="rds-button__icon">
+        <span data-testid="rds-button__icon" className={`rds-button__icon ${iconClass}`}>
           <Icon />
         </span>
       )}

--- a/shared-components/src/components/button/IconButton.tsx
+++ b/shared-components/src/components/button/IconButton.tsx
@@ -7,6 +7,7 @@ import "./button-shared.scss";
 interface IconButtonProps extends Omit<ButtonProps, "icon" | "postfix"> {
   ["aria-label"]: string;
   icon: () => JSX.Element;
+  iconClass?: string;
 }
 
 export const PrimaryIconButton: FC<IconButtonProps> = ({ ...props }) => (

--- a/shared-components/src/components/button/IconButton.tsx
+++ b/shared-components/src/components/button/IconButton.tsx
@@ -7,7 +7,6 @@ import "./button-shared.scss";
 interface IconButtonProps extends Omit<ButtonProps, "icon" | "postfix"> {
   ["aria-label"]: string;
   icon: () => JSX.Element;
-  iconClass?: string;
 }
 
 export const PrimaryIconButton: FC<IconButtonProps> = ({ ...props }) => (


### PR DESCRIPTION
Vi saknar ett enkelt sätt att styla icon-size med offset som hänger ihop med knappen själv.
Lägger till optional klass till elementet som wrappar ikonen för att fixa det.