### PR TITLE
feat: Use numeric line heights, update title4 [release]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # 📖 Change Log
 
+## 0.4.3
+
+### 🎉 Features
+
+- Use numerical values for typography `line-heights`
+- Change `rds-title-4` from `18-22px` to `16-22px`
+
 ## 0.4.2
 
 ### 🎉 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -10008,7 +10008,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@mdx-js/react": "^1.6.22",
-        "@rikstv/shared-components": "0.4.2",
+        "@rikstv/shared-components": "0.4.3",
         "normalize.css": "^8.0.1",
         "prism-react-renderer": "^1.2.1",
         "react-docgen-typescript": "^2.1.0",
@@ -10025,7 +10025,7 @@
     },
     "shared-components": {
       "name": "@rikstv/shared-components",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "devDependencies": {
         "@cypress/react": "^5.9.4",
@@ -10694,7 +10694,7 @@
       "version": "file:portal",
       "requires": {
         "@mdx-js/react": "^1.6.22",
-        "@rikstv/shared-components": "0.4.2",
+        "@rikstv/shared-components": "0.4.3",
         "@types/mdx-js__react": "^1.5.4",
         "@types/react-router-dom": "^5.1.8",
         "normalize.css": "^8.0.1",

--- a/portal/package.json
+++ b/portal/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@mdx-js/react": "^1.6.22",
-    "@rikstv/shared-components": "0.4.2",
+    "@rikstv/shared-components": "0.4.3",
     "prism-react-renderer": "^1.2.1",
     "normalize.css": "^8.0.1",
     "react-docgen-typescript": "^2.1.0",

--- a/shared-components/package.json
+++ b/shared-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rikstv/shared-components",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "publishConfig": {
     "access": "public"
   },

--- a/shared-components/src/components/typography/typography.scss
+++ b/shared-components/src/components/typography/typography.scss
@@ -1,57 +1,59 @@
+/* TODO: linear scaling of target font-size */
+/* https://css-tricks.com/linearly-scale-font-size-with-css-clamp-based-on-the-viewport */
 .rds-display-title {
   font-family: var(--rds-font-family-lg-headlines);
   font-size: clamp(2rem, 6vw, 5rem);
-  line-height: clamp(2.8125rem, 6vw, 7.5rem);
+  line-height: 1.2;
   color: var(--rds-foreground-primary);
 }
 
 .rds-title-1 {
   font-family: var(--rds-font-family-lg-headlines);
   font-size: clamp(1.75rem, 5vw, 2.625rem);
-  line-height: clamp(2.8125rem, 5vw, 3.9375rem);
+  line-height: 1.2;
   color: var(--rds-foreground-primary);
 }
 
 .rds-title-2 {
   font-family: var(--rds-font-family-lg-headlines);
   font-size: clamp(1.5rem, 4vw, 2.125rem);
-  line-height: clamp(2.25rem, 4vw, 3.1875rem);
+  line-height: 1.2;
   color: var(--rds-foreground-primary);
 }
 
 .rds-title-3 {
   font-family: var(--rds-font-family-m-headlines);
-  font-size: clamp(1.25rem, 4vw, 1.5rem);
-  line-height: clamp(1.875rem, 4vw, 2.25rem);
+  font-size: clamp(1.25rem, 3vw, 1.5rem);
+  line-height: 1.2;
   color: var(--rds-heading-accent);
 }
 
 .rds-title-4 {
   font-family: var(--rds-font-family-m-headlines);
-  font-size: clamp(1.125rem, 4vw, 1.375rem);
-  line-height: clamp(1.6875rem, 4vw, 2.0625rem);
+  font-size: clamp(1rem, 2vw, 1.375rem);
+  line-height: 1.2;
   color: var(--rds-foreground-primary);
 }
 
 .rds-body {
   font-family: var(--rds-font-family-body);
-  font-size: clamp(1rem, 4vw, 1.125rem);
-  line-height: clamp(1.5rem, 4vw, 1.6875rem);
+  font-size: clamp(1rem, 2vw, 1.125rem);
+  line-height: 1.5;
   color: var(--rds-foreground-primary);
 }
 
 .rds-sub-body {
   font-family: var(--rds-font-family-body);
-  font-size: clamp(0.875rem, 4vw, 1rem);
-  line-height: clamp(1.5rem, 4vw, 1.5rem);
+  font-size: clamp(0.875rem, 2vw, 1rem);
+  line-height: 1.5;
   color: var(--rds-foreground-primary);
 }
 
 .rds-tag {
   font-family: var(--rds-font-family-body);
   text-transform: uppercase;
-  font-size: clamp(0.75rem, 4vw, 1rem);
-  line-height: clamp(1.125rem, 4vw, 1.5rem);
+  font-size: clamp(0.75rem, 2vw, 1rem);
+  line-height: 1.2;
   letter-spacing: 0.09375rem;
   color: var(--rds-foreground-primary);
 }
@@ -59,15 +61,15 @@
 .rds-bold {
   font-family: var(--rds-font-family-body);
   font-weight: bold;
-  font-size: clamp(1.125rem, 4vw, 1.125rem);
-  line-height: clamp(1.5rem, 4vw, 1.6875rem);
+  font-size: clamp(1.125rem, 2vw, 1.125rem);
+  line-height: 1.5;
   color: var(--rds-foreground-primary);
 }
 
 .rds-meta {
   font-family: var(--rds-font-family-body);
-  font-size: clamp(0.875rem, 4vw, 0.875rem);
-  line-height: clamp(1.125rem, 4vw, 1.3125rem);
+  font-size: clamp(0.875rem, 2vw, 0.875rem);
+  line-height: 1.5;
   color: var(--rds-foreground-overlay-heavy);
 }
 


### PR DESCRIPTION

- use numeric values for line-heights (they are multiplied by current font-size)
- use 16-22px for title4 (feedback from Ragnhild, not updated in Figma afaic)