### PR TITLE
feat: adds lightmode to primary and secondary buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # 📖 Change Log
 
+## 0.6.7
+
+### 🤷 Description
+
+- Adds lightmode for primary and secondary button in strim
+
+### 🎉 Features
+
+- Pimary and secondary buttons wrapped with lightMode component will adjust style accordingly
+- lightBackground attribute can be used to override/trigger the lightMode styling
 
 ## 0.6.3 - 0.6.6
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9539,7 +9539,7 @@
     },
     "shared-components": {
       "name": "@rikstv/shared-components",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "MIT",
       "devDependencies": {
         "@cypress/react": "^5.10.0",

--- a/shared-components/package.json
+++ b/shared-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rikstv/shared-components",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "publishConfig": {
     "access": "public"
   },

--- a/shared-components/src/components/button/BaseButton.tsx
+++ b/shared-components/src/components/button/BaseButton.tsx
@@ -6,6 +6,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   icon?: () => JSX.Element;
   className?: string;
   iconClass?: string;
+  lightBackground?: boolean;
 }
 
 interface BaseButtonProps extends ButtonProps {
@@ -24,6 +25,7 @@ export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
       postfix,
       icon: Icon,
       iconClass = "",
+      lightBackground = false,
       disabled,
       className = "",
       "aria-busy": ariaBusy,
@@ -39,7 +41,7 @@ export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
       aria-busy={isLoading || ariaBusy}
       className={`${buttonStyle} rds-button__shared rds-button__shared--${buttonType} rds-button--${buttonType} ${
         isLoading ? "rds-button--loading" : ""
-      } ${className}`}
+      } ${lightBackground ? "rds-light" : ""} ${className}`}
     >
       {Icon && (
         <span data-testid="rds-button__icon" className={`rds-button__icon ${iconClass}`}>

--- a/shared-components/src/components/button/button-shared.scss
+++ b/shared-components/src/components/button/button-shared.scss
@@ -110,3 +110,47 @@
 
   @include mix.with-keyboard-focus;
 }
+
+.rds-light {
+  .rds-button__shared--primary,
+  &.rds-button__shared--primary {
+    --common-button--primary-color: var(--rds-foreground-primary);
+    --common-button--primary-bg: var(--rds-button-primary-fg);
+
+    &:hover {
+      --common-button--primary-hover-bg: var(--rds-foreground-tertiary);
+    }
+
+    &:active {
+      box-shadow: none;
+      --common-button--primary-pressed-bg: var(--rds-background-primary);
+    }
+
+    &:disabled {
+      --common-button--disabled-color: var(--rds-button-tertiary-hover-bg);
+    }
+  }
+}
+
+.rds-light {
+  .rds-button__shared--secondary,
+  &.rds-button__shared--secondary {
+    --common-button--secondary-color: var(--rds-button-tertiary-hover-bg);
+    --common-button--secondary-border-color: var(--rds-button-tertiary-hover-bg);
+    --common-button--secondary-bg: var(--surface-background);
+
+    &:hover {
+      --common-button--secondary-hover-bg: var(--rds-button-primary-fg);
+      --common-button--secondary-hover-color: var(--rds-foreground-primary);
+    }
+
+    &:active {
+      --common-button--secondary-pressed-color: var(--rds-foreground-primary);
+      --common-button--secondary-pressed-bg: var(--rds-button-primary-fg);
+    }
+
+    &:disabled {
+      --common-button--disabled-color: var(--rds-button-primary-fg);
+    }
+  }
+}

--- a/shared-components/src/components/button/button.mdx
+++ b/shared-components/src/components/button/button.mdx
@@ -60,3 +60,47 @@ Kan brukes til å vise pris eller annen viktig info
   Spill av
 </PrimaryButton>
 ```
+
+## Lys bakgrunn
+
+Denne er kun implementert for Strim per nå.
+
+## PrimaryButton
+```tsx live=true 
+<LightMode style={{
+    backgroundColor: "var(--surface-background)",
+    padding: "var(--rds-spacing--32)",
+    borderRadius: "var(--rds-roundness--default)"
+}}>
+<PrimaryButton postfix="" isLoading={false} disabled={false}>
+  Hello world
+</PrimaryButton>
+</LightMode>
+```
+## SecondaryButton
+```tsx live=true
+<LightMode style={{
+    backgroundColor: "var(--surface-background)",
+    padding: "var(--rds-spacing--32)",
+    borderRadius: "var(--rds-roundness--default)"
+}}>
+<SecondaryButton postfix="" isLoading={false} disabled={false}>
+  Hello world
+</SecondaryButton>
+</LightMode>
+```
+
+### With 'lightBackground' attribute
+
+## PrimaryButton
+```tsx live=true 
+<div style={{
+    backgroundColor: "var(--surface-background)",
+    padding: "var(--rds-spacing--32)",
+    borderRadius: "var(--rds-roundness--default)"
+}}>
+<PrimaryButton postfix="" isLoading={false} disabled={false} lightBackground>
+  Hello world
+</PrimaryButton>
+</div>
+```


### PR DESCRIPTION
Adds lightmode for primary and secondary buttons. Can be overridden using lightBackground prop on the buttons. Only implemented for strim. 