### PR TITLE
chore:update colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # 📖 Change Log
 
-## 0.7.1
+## 0.8.0
 
-### 🤷 Description
+### 💥 BREAKING CHANGES 💥
 
 - Changes the secondary and tertiary background colors. Also adds new color "--rds-background-card"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 📖 Change Log
 
+## 0.7.1
+
+### 🤷 Description
+
+- Changes the secondary and tertiary background colors. Also adds new color "--rds-background-card"
+
 ## 0.7.0
 
 ### 💥 BREAKING CHANGES 💥

--- a/shared-components/package.json
+++ b/shared-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rikstv/shared-components",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "publishConfig": {
     "access": "public"
   },

--- a/shared-components/package.json
+++ b/shared-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rikstv/shared-components",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "publishConfig": {
     "access": "public"
   },

--- a/shared-components/src/components/core/docs/Example.tsx
+++ b/shared-components/src/components/core/docs/Example.tsx
@@ -28,6 +28,7 @@ export const Colors: FC = () => (
       <ColorSwatch color="--rds-background-primary" usage={["app background"]} />
       <ColorSwatch color="--rds-background-secondary" usage={["contrast background"]} />
       <ColorSwatch color="--rds-background-tertiary" usage={["contrast background"]} />
+      <ColorSwatch color="--rds-background-card" usage={["contrast background"]} />
     </ExampleGrid>
 
     <ExampleGrid title="Transparent objects">

--- a/shared-components/src/components/core/rtv.scss
+++ b/shared-components/src/components/core/rtv.scss
@@ -18,8 +18,9 @@
 
   --rds-background-primary-rgb: 37, 37, 37;
   --rds-background-primary: rgb(var(--rds-background-primary-rgb));
-  --rds-background-secondary: #434343;
-  --rds-background-tertiary: #0b0b0b;
+  --rds-background-secondary: #0b0b0b;
+  --rds-background-tertiary: #434343;
+  --rds-background-card: #3b3b3b;
 
   --rds-foreground-overlay-soft: rgba(255, 255, 255, 0.1);
   --rds-foreground-overlay-medium: rgba(255, 255, 255, 0.3);

--- a/shared-components/src/components/core/strm.scss
+++ b/shared-components/src/components/core/strm.scss
@@ -16,8 +16,9 @@
 
   --rds-background-primary-rgb: 0, 42, 42; // #002a2a
   --rds-background-primary: rgb(var(--rds-background-primary-rgb));
-  --rds-background-secondary: #001d1d;
-  --rds-background-tertiary: #001515;
+  --rds-background-secondary: #001515;
+  --rds-background-tertiary: #004b50;
+  --rds-background-card: #193f3f;
 
   --rds-foreground-overlay-soft: rgba(255, 255, 255, 0.1);
   --rds-foreground-overlay-medium: rgba(255, 255, 255, 0.3);


### PR DESCRIPTION
Updates the background colors for RiksTV and Strim according to the Figma spec. Note that background-secondary and background-tertiary have been changed. Also adds a new color: '--rds-background-card'

Color reference: https://www.figma.com/file/U6AAqeRQ5EnOr9b8Hqltbt/Client%3A-Web-TV?node-id=1796%3A44651